### PR TITLE
Misc fixes (reenable isort)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,4 +38,4 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install isort
-#          isort -c ksmm
+          isort -c ksmm

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ given a kernelspec template like the following.
 
 ```json
 {
-  "cmd": [
+  "argv": [
     "slurm", "run", "--mem={mem}", "--cpu={cpu}", "python3.8", "-m", "ipykernel"
   ],
-  "title": "Python 3.8 {mem}/{cpu}",
+  "display_name": "Python 3.8 {mem}/{cpu}",
   "params": {
     "mem": ["100G", "500G", "1T"],
     "cpu": { "min": 1, "max": 300}

--- a/ksmm/__init__.py
+++ b/ksmm/__init__.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from ._version import __version__
 from .handlers import setup_handlers
 
-
 HERE = Path(__file__).parent.resolve()
 
 with (HERE / "labextension" / "package.json").open() as fid:


### PR DESCRIPTION
@echarles sorry that isort has inscrutable error message, usually I just run `isort ksmm`, and it will reformat the import to what it consider good.

I'm also ok to unconditionally remove isort, it was just a stop gap to help formatting the codebase to be consistant.