### PR TITLE
Various fixes to improve usability

### DIFF
--- a/ksmm/kernel_schema.py
+++ b/ksmm/kernel_schema.py
@@ -23,12 +23,6 @@ kernel_schema = '''{
     "parameters": {
       "type": "object",
       "properties": {
-        "cores": { "type": "string", "enum": [], "title": "CPU Cores" },
-        "memory": {
-          "type": "string",
-          "enum": [],
-          "title": "Memory"
-        }
       }
     },
     "metadata": { "type": "object", "title": "" }

--- a/ksmm/templating.py
+++ b/ksmm/templating.py
@@ -103,7 +103,7 @@ def format_tpl(spec, **kwargs):
         if k in ("argv", "display_name"):
             it = spec["metadata"]["template"]["tpl"][k]
             static_spec[k] = recursive_format(
-                it, spec["metadata"]["template"]["mapping"], **kwargs
+                it, spec["metadata"]["template"].get("mapping", {}), **kwargs
             )
         else:
             static_spec[k] = v

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "install:extension": "jupyter labextension develop --overwrite .",
     "prepare": "jlpm run clean && jlpm run build:prod",
     "watch": "run-p watch:src watch:labextension",
-    "watch:labextension": "jupyter labextension watch .",
+    "watch:labextension": "jupyter-labextension watch .",
     "watch:src": "tsc -w"
   },
   "dependencies": {
@@ -57,15 +57,17 @@
     "@rjsf/core": "^2.4.2",
     "@types/react-jsonschema-form": "1.7.6",
     "bootstrap": "^4.6.0",
+    "react": "^17.0.2",
     "react-bootstrap": "2.0.0-beta.2",
-    "react-jsonschema-form": "1.8.1",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "react-jsonschema-form": "1.8.1"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.0.0",
     "@popperjs/core": "^2.9.2",
-    "@types/react-bootstrap": "^0.32.25",
     "@types/lodash": "^4.14.168",
+    "@types/react": "17.0.11",
+    "@types/react-bootstrap": "^0.32.25",
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",
     "eslint": "^7.27.0",
@@ -78,6 +80,9 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.2",
     "typescript": "~4.1.3"
+  },
+  "resolutions": {
+    "**/@types/react": "17.0.11"
   },
   "sideEffects": [
     "style/*.css"

--- a/src/components/envvar.tsx
+++ b/src/components/envvar.tsx
@@ -31,8 +31,8 @@ const EnvVarForm = (props: any) => {
       }
       <button
         type="button"
-        onClick={(e: any) => { 
-          formData['NEW_ENV'] = 'new_value';
+        onClick={(e: any) => {
+          formData[''] = '';
           setToggle(!toggle);
         }}
       >

--- a/src/components/keyval.tsx
+++ b/src/components/keyval.tsx
@@ -29,6 +29,7 @@ const KeyValueWidget = (props: any) => {
     <>
       <input
         type="string"
+        placeholder="ENV_VAR"
         value={formKey}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           handleKeyChange(formKey, e.target.value);
@@ -36,7 +37,9 @@ const KeyValueWidget = (props: any) => {
       />
       <input
         type="string"
+        placeholder="MY VALUE"
         value={formVal}
+        size={75}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           handleValueChange(formKey, e.target.value);
         }}

--- a/src/components/kscard.tsx
+++ b/src/components/kscard.tsx
@@ -1,54 +1,63 @@
 import React from "react";
+import { OverlayTrigger, Tooltip } from "react-bootstrap";
 import Card from "react-bootstrap/Card";
-import { FaRegEdit, FaCopy, FaTrash, FaEyeDropper } from "react-icons/fa";
+import { FaRegEdit, FaCopy, FaTrash, FaWpforms } from "react-icons/fa";
 
 const KsCard = (props: any): JSX.Element => {
   const { 
-    cardPayload, 
+    kernelSpec,
     handleSelectKernelspec, 
     handleCopyKernelspec, 
     handleDeleteKernelspec,
     handleTemplateKernelspec
   } = props;
+
+  const renderToolTip = (props: any): JSX.Element => <Tooltip id='card-tooltip' {...props}>{kernelSpec._ksmm.fs_path}</Tooltip>;
+
   return (
     <Card
       style={{
         width: "12rem",
         height: "12rem",
       }}
-      key={cardPayload.kernel_name}
+      key={kernelSpec._ksmm.fs_path}
     >
       <Card.Body>
-        <Card.Title>{cardPayload.kernel_name}</Card.Title>
-        <Card.Subtitle>{cardPayload.jupyter_name}</Card.Subtitle>
+        <OverlayTrigger
+            placement="bottom"
+            overlay={renderToolTip}
+        >
+            <Card.Title>{kernelSpec.display_name}</Card.Title>
+        </OverlayTrigger>
       </Card.Body>
       <Card.Footer className="align-left">
-        { handleSelectKernelspec && <a
+        { kernelSpec._ksmm?.writeable ? <a
           style={{ cursor: "pointer" }}
-          onClick={() => handleSelectKernelspec(cardPayload.kernel_name)}
+          onClick={() => handleSelectKernelspec(kernelSpec)}
           >
-            <FaRegEdit />
+            <FaRegEdit className='ksmm-button-enabled' title='Edit' />
           </a>
+          : <FaRegEdit className='ksmm-button-disabled'/>
         }
-        { handleCopyKernelspec && <a
+        <a
           style={{ cursor: "pointer" }}
-          onClick={() => handleCopyKernelspec(cardPayload.kernel_name)}
+          onClick={() => handleCopyKernelspec(kernelSpec)}
           >
-            <FaCopy />
+            <FaCopy className='ksmm-button-enabled' title='Copy' />
+        </a>
+        { kernelSpec._ksmm?.deletable ? <a
+          style={{ cursor: "pointer" }}
+          onClick={() => handleDeleteKernelspec(kernelSpec)}
+          >
+            <FaTrash className='ksmm-button-enabled' title='Delete' />
           </a>
+          : <FaTrash className='ksmm-button-disabled' />
         }
-        { handleDeleteKernelspec && <a
-          style={{ cursor: "pointer" }}
-          onClick={() => handleDeleteKernelspec(cardPayload.kernel_name)}
+        { kernelSpec.metadata?.template && <a
+          style={{ cursor: "pointer", float: 'right' }}
+          onClick={() => handleTemplateKernelspec(kernelSpec)}
           >
-            <FaTrash />
-          </a>
-        }
-        { handleTemplateKernelspec && <a
-          style={{ cursor: "pointer" }}
-          onClick={() => handleTemplateKernelspec(cardPayload)}
-          >
-            <FaEyeDropper />
+            <FaWpforms className='ksmm-button-enabled' title='Generate with Template' />
           </a>
         }
       </Card.Footer>

--- a/style/index.css
+++ b/style/index.css
@@ -8,6 +8,15 @@
     left: 0;
 }
 
+.ksmm-button-disabled {
+    color: var(--jp-brand-color1);
+    opacity: 0.3;
+}
+
+.ksmm-button-enabled {
+    color: var(--jp-brand-color1);;
+}
+
 div.card{
     margin: 12px;
 


### PR DESCRIPTION
On a high level this:
1. Moves to two types of kernel groups - those the user manages and those from elsewhere. In an enterprise setting, this is pretty common setup (even in an non-enterprise setting, this moves the python3 default kernel outside of something a user would be encouraged to edit)
2. Improves error handling
3. A lot of UX tweaks (e.g. naming, actions based on permissions, showing where the kernel is on disk, etc.)