### PR TITLE
Ensure long kernel names can fit on cards

### DIFF
--- a/src/components/kscard.tsx
+++ b/src/components/kscard.tsx
@@ -18,19 +18,11 @@ const KsCard = (props: any): JSX.Element => {
     <Card
       style={{
         width: "12rem",
-        height: "12rem",
+        minHeight: "12rem",
       }}
       key={kernelSpec._ksmm.fs_path}
     >
-      <Card.Body>
-        <OverlayTrigger
-            placement="bottom"
-            overlay={renderToolTip}
-        >
-            <Card.Title>{kernelSpec.display_name}</Card.Title>
-        </OverlayTrigger>
-      </Card.Body>
-      <Card.Footer className="align-left">
+      <Card.Header className="align-left">
         { kernelSpec._ksmm?.writeable ? <a
           style={{ cursor: "pointer" }}
           onClick={() => handleSelectKernelspec(kernelSpec)}
@@ -60,7 +52,15 @@ const KsCard = (props: any): JSX.Element => {
             <FaWpforms className='ksmm-button-enabled' title='Generate with Template' />
           </a>
         }
-      </Card.Footer>
+      </Card.Header>
+      <Card.Body>
+        <OverlayTrigger
+            placement="bottom"
+            overlay={renderToolTip}
+        >
+            <Card.Title>{kernelSpec.display_name}</Card.Title>
+        </OverlayTrigger>
+      </Card.Body>
     </Card>
   );
 }


### PR DESCRIPTION
Kernel actions are now on the top and the box will grow to accommodate long names:
![image](https://user-images.githubusercontent.com/1813603/135687155-299dce6e-be39-467a-aaab-21200f38416c.png)

It turns out this happens in practice because generated kernels have a lot of template args and you end up putting them all in the name.